### PR TITLE
skip DNS check if not connected to the internet

### DIFF
--- a/src/assegai/modules/validator/Validator.php
+++ b/src/assegai/modules/validator/Validator.php
@@ -108,7 +108,12 @@ class Validator extends modules\Module
                                }
                                // check DNS
                                if ($isValid && !(checkdnsrr($domain,"MX") || checkdnsrr($domain,"A"))) {
-                                   $isValid = false;
+                                   // hmm, the domain has no MX records
+                                   if (checkdnsrr('gmail.com',"MX")) {
+                                       // but Gmail does. the other domain must be dodgy
+                                       $isValid = false;
+                                   }
+                                   // otherwise: probably running off-line or maybe DNS service is not working
                                }
                            }
                            return $isValid;


### PR DESCRIPTION
When offline, all email checks fail. Obviously this is not relevant when running a server on the internet but it is quite annoying when I'm testing on the train. In this patch I assume that Gmail always has an MX record and therefore if it doesn't then you're not connected to the internet. Tested on the TF registration page and works as expected (a nonsense domain passes without internet connection but fails with internet connection; valid domains always pass).
