### PR TITLE
don't emit PHP NOTICE when trying to autoload

### DIFF
--- a/src/assegai/Autoloader.php
+++ b/src/assegai/Autoloader.php
@@ -123,8 +123,16 @@ namespace assegai
                         'Exception' => 'exceptions',
                         'Model' => 'models',
                         'View' => 'views');
-                    $filename = $this->conf->get('apps_path') . '/' . strtolower($app) . '/'
-                        . $paths[$type] . '/' . str_replace('_', '/', strtolower($class)) . '.php';
+                    if(array_key_exists($type, $paths))
+                    {
+                        $filename = $this->conf->get('apps_path') . '/' . strtolower($app) . '/'
+                            . $paths[$type] . '/' . str_replace('_', '/', strtolower($class)) . '.php';
+                    }
+                    else
+                    {
+                        $filename = false;
+                    }
+
                 }
             }
             return $filename != "" ? $filename : false;

--- a/src/assegai/Autoloader.php
+++ b/src/assegai/Autoloader.php
@@ -130,7 +130,7 @@ namespace assegai
                     }
                     else
                     {
-                        $filename = false;
+                        $filename = "";
                     }
 
                 }


### PR DESCRIPTION
`$classname` is frequently things like `'pupil_id_in_payment_confirmation'`, which splits to form

```
$app = 'pupil'
$type = 'id'
$class = 'in_payment_confirmation'
```

This generates a NOTICE when `$type` is not one of `'Exception'`, `'Model'` or `'View'`, before returning something like `'`_`...blah...`_`/apps/pupil//in/payment/confirmation.php'`.