### PR TITLE
Parameter types in doc comments

### DIFF
--- a/src/assegai/Request.php
+++ b/src/assegai/Request.php
@@ -175,8 +175,8 @@ class Request extends Stateful
 
     /**
      * Returns an escaped post variable or default.
-     * @param $varname is the variable's name.
-     * @param $default is the default to be returned if the variable
+     * @param string $varname is the variable's name.
+     * @param mixed  $default is the default to be returned if the variable
      * doesn't exist.
      */
     function post($varname, $default = false)
@@ -186,8 +186,8 @@ class Request extends Stateful
 
     /**
      * Returns an escaped get variable or default.
-     * @param $varname is the variable's name.
-     * @param $default is the default to be returned if the variable
+     * @param string $varname is the variable's name.
+     * @param mixed  $default is the default to be returned if the variable
      * doesn't exist.
      */
     function get($varname, $default = false)


### PR DESCRIPTION
This is according to [the syntax here](http://www.phpdoc.org/docs/latest/references/phpdoc/tags/param.html). I've been using [PhpStorm](https://www.jetbrains.com/phpstorm/) and it shows an error everywhere we use `->get()` or `->post()` because it doesn't understand the type from the doc comment.