### PR TITLE
initialise Request object for Framework::runuri()

### DIFF
--- a/src/assegai/Request.php
+++ b/src/assegai/Request.php
@@ -59,6 +59,8 @@ class Request extends Stateful
     function __construct()
     {
         parent::__construct();
+        $this->getvars = array();
+        $this->postvars = array();
     }
 
     function setDependencies(Server $server, Security $sec)


### PR DESCRIPTION
The [`runuri()` function](https://github.com/Etenil/assegai/blob/a657ce2/src/assegai/Framework.php#L107-L119) is throwing errors at me because Request->getvars is not an array.

```
An error occured while running your code:
array_map(): Argument #2 should be an array
0 - at assegai\AppEngine::phpErrorHandler() in  on line 
1 - array_map() in /home/alexander/Source_Code/TutorfairWebsite/tutorfair/vendor/etenil/assegai/src/assegai/Request.php on line 213
2 - at assegai\Request::allGet() in /home/alexander/Source_Code/TutorfairWebsite/tutorfair/apps/common/controllers/Common.php on line 84
3 - at common\controllers\Common::preRequest() in /home/alexander/Source_Code/TutorfairWebsite/tutorfair/vendor/etenil/assegai/src/assegai/AppEngine.php on line 383
4 - at assegai\AppEngine::process() in /home/alexander/Source_Code/TutorfairWebsite/tutorfair/vendor/etenil/assegai/src/assegai/AppEngine.php on line 178
5 - at assegai\AppEngine::serve() in /home/alexander/Source_Code/TutorfairWebsite/tutorfair/vendor/etenil/assegai/src/assegai/Framework.php on line 95
6 - at assegai\Framework::serve() in /home/alexander/Source_Code/TutorfairWebsite/tutorfair/vendor/etenil/assegai/src/assegai/Framework.php on line 118
7 - at assegai\Framework::runuri() in /home/alexander/Source_Code/TutorfairWebsite/public/mvccron.php on line 34
```

My /etc/php5/cli/php.ini error_reporting directive is set to

```
error_reporting = E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED
```