### PR TITLE
don't generate "headers already sent" errors (master branch)

### DIFF
--- a/src/assegai/Stateful.php
+++ b/src/assegai/Stateful.php
@@ -231,12 +231,14 @@ class Stateful
             }
         }
 
-        foreach($this->cookievars as $cookiename => $cookieval) {
-            if($cookieval === null) {
-                setcookie($cookiename, $cookieval, time() - $this->cookies_max_age, '/');
-            }
-            else {
-                setcookie($cookiename, $cookieval, time() + $this->cookies_max_age, '/');
+        if(!headers_sent()) {
+            foreach($this->cookievars as $cookiename => $cookieval) {
+                if($cookieval === null) {
+                    setcookie($cookiename, $cookieval, time() - $this->cookies_max_age, '/');
+                }
+                else {
+                    setcookie($cookiename, $cookieval, time() + $this->cookies_max_age, '/');
+                }
             }
         }
 	}


### PR DESCRIPTION
Often when there is a 500 error, Assegai generates another 150 "headers already sent" errors to go with it. Obviously this makes the logs difficult to read.