### PR TITLE
don't generate "headers already sent" errors (issue 33 branch)

### DIFF
--- a/src/assegai/Stateful.php
+++ b/src/assegai/Stateful.php
@@ -247,17 +247,19 @@ class Stateful
             }
         }
 
-        foreach($this->cookievars as $cookiename => $cookiedef) {
-            if($cookiedef['value'] === null) {
-                setcookie($cookiename, null, time() - 3600, '/'); // Expiring the cookie
-            }
-            else {
-                setcookie(
-                    $cookiename,
-                    $cookiedef['value'],
-                    time() + $cookiedef['max_age'],
-                    '/'
-                );
+        if(!headers_sent()) {
+            foreach($this->cookievars as $cookiename => $cookiedef) {
+                if($cookiedef['value'] === null) {
+                    setcookie($cookiename, null, time() - 3600, '/'); // Expiring the cookie
+                }
+                else {
+                    setcookie(
+                        $cookiename,
+                        $cookiedef['value'],
+                        time() + $cookiedef['max_age'],
+                        '/'
+                    );
+                }
             }
         }
 	}


### PR DESCRIPTION
Often when there is a 500 error, Assegai generates another 150 "headers already sent" errors to go with it. I realised that this would conflict with the issue that Lewi raised, so I've done it in both branches.